### PR TITLE
Fix: Fixed vulnerabilities, optimized the Dockerfile and removed redundancy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM amazonlinux:latest
+
+ENV NODE_VERSION=12.x
+
 USER root
+
+RUN yum update -y && \
+    yum install wget curl tar gzip which  -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl --silent --location https://rpm.nodesource.com/setup_${NODE_VERSION} | bash - && \
+    yum install nodejs -y && \
+    npm install -g opencollective
+
 COPY ./install.sh /root/install.sh
+
 COPY ./service.sh /root/service.sh
+
 RUN chmod 755 /root/install.sh && chmod 755 /root/service.sh
-RUN yum install -y wget curl tar gzip which
+
 RUN /root/install.sh
+
 ENTRYPOINT [ "bash","-c","/root/service.sh" ]

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ##### Ininition Enviroment #####
-yum install -y wget curl tar gzip which
 cd ~
 wget https://repo.anaconda.com/archive/Anaconda3-2019.07-Linux-x86_64.sh -O ~/Anaconda3-2019.07-Linux-x86_64.sh
 mkdir ~/.conda/
@@ -22,11 +21,6 @@ else
     echo "Unable to determine region！";
     pipargs=''
 fi
-
-##### Install NodeJs #####
-curl --silent --location https://rpm.nodesource.com/setup_12.x | bash -
-yum install -y nodejs
-npm install -g opencollective
 
 ##### Copy To Home Directory #####
 source ~/.bashrc


### PR DESCRIPTION

*Description of changes:*
The Docker image had multiple medium level vulnerabilities. This is now fixed with system package update.

Before fix:
<img width="992" alt="Screenshot 2022-01-22 at 12 58 54 PM" src="https://user-images.githubusercontent.com/10575622/150629334-fff50abf-e1bb-423a-b099-09e5b9f7bbe6.png">

After Fix
<img width="1111" alt="Screenshot 2022-01-22 at 1 00 30 PM" src="https://user-images.githubusercontent.com/10575622/150629374-26d47348-aa61-4ad4-b0bb-75dcb199e4ab.png">



The install.sh contains` yum install -y wget curl tar gzip which` and Dockerfile contains `RUN yum install -y wget curl tar gzip which`. This is redundant. This will consume extra time will performing docker build. This is fixed with removing it from install.sh


The node is being installed from install.sh  with a fixed node version. This installation of node and related components are  moved to Dockerfile with a ENV variable that can now control node version as well. Example node 12.x contains vulnerabilities can now be simply controlled from ENV variable with updated version. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
